### PR TITLE
Update to fix a bug for interfaces

### DIFF
--- a/AsyncMediator.Test/AsyncMediator.Test.csproj
+++ b/AsyncMediator.Test/AsyncMediator.Test.csproj
@@ -58,6 +58,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Fakes\ChainedEventHandler.cs" />
+    <Compile Include="Fakes\HandlerForInterfaceDeferringSingleEvent.cs" />
+    <Compile Include="Fakes\HandlerForInterfaceDeferringMultipleEvents.cs" />
+    <Compile Include="Fakes\HandlerForInterfaceWithoutAdditionalEvents.cs" />
     <Compile Include="Fakes\TestMultipleCommandsWithResult.cs" />
     <Compile Include="Fakes\DependentEventHandler.cs" />
     <Compile Include="Fakes\FakeDataStore.cs" />

--- a/AsyncMediator.Test/Fakes/FakeEvent.cs
+++ b/AsyncMediator.Test/Fakes/FakeEvent.cs
@@ -1,7 +1,11 @@
 ﻿namespace AsyncMediator.Test
 {
-    public class FakeEvent : IDomainEvent
+    public class FakeEvent : IFakeEvent
     {
         public int Id { get; set; }
+    }
+
+    public interface IFakeEvent : IDomainEvent
+    {
     }
 }

--- a/AsyncMediator.Test/Fakes/HandlerForInterfaceDeferringMultipleEvents.cs
+++ b/AsyncMediator.Test/Fakes/HandlerForInterfaceDeferringMultipleEvents.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+
+namespace AsyncMediator.Test
+{
+    [HandlerOrder(2)]
+    public class HandlerForInterfaceDeferringMultipleEvents : IEventHandler<IFakeEvent>
+    {
+        private readonly IMediator _mediator;
+
+        public HandlerForInterfaceDeferringMultipleEvents(IMediator mediator)
+        {
+            this._mediator = mediator;
+        }
+
+        public virtual Task Handle(IFakeEvent @event)
+        {
+            this._mediator.DeferEvent(new FakeEventFromHandler { Id = 1 });
+            this._mediator.DeferEvent(new FakeEventTwoFromHandler { Id = 1 });
+            return Task.FromResult(2);
+        }
+    }
+}

--- a/AsyncMediator.Test/Fakes/HandlerForInterfaceDeferringSingleEvent.cs
+++ b/AsyncMediator.Test/Fakes/HandlerForInterfaceDeferringSingleEvent.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace AsyncMediator.Test
+{
+    [HandlerOrder(1)]
+    public class HandlerForInterfaceDeferringSingleEvent : IEventHandler<IFakeEvent>
+    {
+        private readonly IMediator _mediator;
+
+        public HandlerForInterfaceDeferringSingleEvent(IMediator mediator)
+        {
+            this._mediator = mediator;
+        }
+
+        public virtual Task Handle(IFakeEvent @event)
+        {
+            this._mediator.DeferEvent(new FakeEventFromHandler { Id = 1 });
+            return Task.FromResult(1);
+        }
+    }
+}

--- a/AsyncMediator.Test/Fakes/HandlerForInterfaceWithoutAdditionalEvents.cs
+++ b/AsyncMediator.Test/Fakes/HandlerForInterfaceWithoutAdditionalEvents.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace AsyncMediator.Test
+{
+    [HandlerOrder(1)]
+    public class HandlerForInterfaceWithoutAdditionalEvents : IEventHandler<IFakeEvent>
+    {
+        public virtual Task Handle(IFakeEvent @event)
+        {
+            return Task.FromResult(3);
+        }
+    }
+}

--- a/AsyncMediator/Infrastructure/Mediator.cs
+++ b/AsyncMediator/Infrastructure/Mediator.cs
@@ -73,7 +73,7 @@ namespace AsyncMediator
 
         private IEnumerable<IEventHandler<TEvent>> GetEventHandlers<TEvent>(TEvent @event) where TEvent : IDomainEvent
         {
-            var genericHandlerType = _handlerCache.GetOrAdd(@event.GetType(), typeof(IEventHandler<>).MakeGenericType(@event.GetType()));
+            var genericHandlerType = _handlerCache.GetOrAdd(typeof(TEvent), typeof(IEventHandler<>).MakeGenericType(typeof(TEvent)));
             var handlers = _multiInstanceFactory(genericHandlerType);
 
             return handlers


### PR DESCRIPTION
The bug was caused by trying to execute an event and specifying the
type. This meant that you could not pass in the generic parameter of the
event you wanted to execute. I changed it to get the type from the
generic parameter that was passed in and this seems to have fixed the
issue